### PR TITLE
サイドメニューにおける県内の最新感染動向の表示有効化

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -113,11 +113,11 @@ export default {
   computed: {
     items() {
       return [
-        /* {
+        {
           icon: 'mdi-chart-timeline-variant',
           title: this.$t('県内の最新感染動向'),
           link: this.localePath('/')
-        }, */
+        },
         /* {
           icon: 'covid',
           title: this.$t('新型コロナウイルス感染症が心配なときに'),


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #28

## 📝 関連する issue / Related Issues
- #28

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- SideNavigation.vueにおいて、コメントアウトされたメニューを有効化しました。
- issueにも書きましたが、現在コメントアウトされているので、意図された無効化かもしれません。一応pull requestを出してみますので、表示をご確認いただければと思います。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![image](https://user-images.githubusercontent.com/5077109/79082965-f1caf380-7d65-11ea-8952-6847b35bdde9.png)
